### PR TITLE
bund: use sctpStartEchoClient instead of sctpStartClient

### DIFF
--- a/bund/BundCookieAckAndData.seq
+++ b/bund/BundCookieAckAndData.seq
@@ -51,7 +51,7 @@ vCapture($IF0);
 
 sctpCheckEnv($IF0);
 
-sctpStartClient($IF0);
+sctpStartEchoClient($IF0);
 
 vListen($IF0);
 


### PR DESCRIPTION
When COOKIE-ACK is sent bundled with DATA, NUT should do read
first. Otherwise, NUT will send abort(on Linux) because of
unread data at last.

Signed-off-by: Jianwen Ji jijianwen@gmail.com
